### PR TITLE
fix: show active user overrides

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -90,7 +90,19 @@ func (c *InstallCmd) Run() error {
 	}
 
 	c.describeDependencies(dependencies)
-	c.describeRuntimeSourcesAndPermissions(manifest)
+	granted := manifest.Override
+	version := branch
+	if c.Release != "" {
+		version = c.Release
+	} else if c.Commit != "" {
+		version = c.Commit
+	}
+	saved := false
+	if override, loadErr := cpak.LoadOverride(remote, version); loadErr == nil {
+		granted = override
+		saved = true
+	}
+	c.describeRuntimeSourcesAndPermissions(manifest, granted, saved, remote)
 
 	if !c.Yes && !c.SignedInstaller && !tools.ConfirmOperation("Do you want to continue?") {
 		return nil
@@ -144,7 +156,7 @@ func (c *InstallCmd) describeDependencies(dependencies []cpak.ResolvedDependency
 	c.Logger.Info("")
 }
 
-func (c *InstallCmd) describeRuntimeSourcesAndPermissions(manifest *types.CpakManifest) {
+func (c *InstallCmd) describeRuntimeSourcesAndPermissions(manifest *types.CpakManifest, granted types.Override, saved bool, origin string) {
 	sources := cpak.RuntimeSourcesForArchitecture(manifest.RuntimeSources, runtime.GOARCH)
 	if len(sources) > 0 {
 		c.Logger.Info("The following files will be downloaded from third parties:")
@@ -154,8 +166,11 @@ func (c *InstallCmd) describeRuntimeSourcesAndPermissions(manifest *types.CpakMa
 		c.Logger.Info("")
 	}
 
+	if saved {
+		c.Logger.Warning("A saved user override replaces the package permissions for %s.", tools.SanitizeForDisplay(origin))
+	}
 	c.Logger.Info("The following permissions will be granted:")
-	c.describePermissions(manifest.Override)
+	c.describePermissions(granted)
 	c.Logger.Info("")
 }
 

--- a/cmd/install_prompt_test.go
+++ b/cmd/install_prompt_test.go
@@ -118,12 +118,13 @@ func TestTheInstallPromptOnlyShowsRuntimeSourcesForThisArchitecture(t *testing.T
 	}
 	var output bytes.Buffer
 	command := &InstallCmd{Base: cli.Base{Logger: clilog.NewWriter(&output, &output)}}
-	command.describeRuntimeSourcesAndPermissions(&types.CpakManifest{
+	manifest := &types.CpakManifest{
 		RuntimeSources: []types.RuntimeSource{
 			{URL: "https://example.com/native", Size: 1, Architecture: runtime.GOARCH},
 			{URL: "https://example.com/other", Size: 1, Architecture: other},
 		},
-	})
+	}
+	command.describeRuntimeSourcesAndPermissions(manifest, manifest.Override, false, "")
 	printed := output.String()
 	if !strings.Contains(printed, "/native") || strings.Contains(printed, "/other") {
 		t.Fatalf("runtime source prompt: %q", printed)
@@ -165,7 +166,7 @@ func TestTheInstallPromptLetsNoPublisherValueMoveTheCursor(t *testing.T) {
 			Description: "a library nobody asked for" + tainted,
 		},
 	}})
-	command.describeRuntimeSourcesAndPermissions(manifest)
+	command.describeRuntimeSourcesAndPermissions(manifest, manifest.Override, false, "")
 
 	printed := output.String()
 	// The line breaks are the prompt's own, so the rule is applied to what is
@@ -187,5 +188,25 @@ func TestTheInstallPromptLetsNoPublisherValueMoveTheCursor(t *testing.T) {
 	}
 	if got := strings.Count(printed, `\u009b`); got != 18 {
 		t.Fatalf("the single character control sequences were spelled out %d times, want twice per printed value: %q", got, printed)
+	}
+}
+
+func TestTheInstallPromptShowsTheSavedRuntimeOverride(t *testing.T) {
+	var output bytes.Buffer
+	command := &InstallCmd{Base: cli.Base{Logger: clilog.NewWriter(&output, &output)}}
+	manifest := &types.CpakManifest{Override: types.Override{SessionBus: types.DBusPolicy{
+		Own: []string{"com.steampowered.PressureVessel.*"},
+	}}}
+	saved := types.Override{SessionBus: types.DBusPolicy{
+		Own: []string{"com.steampowered.PressureVessel.LaunchAlongsideSteam"},
+	}}
+
+	command.describeRuntimeSourcesAndPermissions(manifest, saved, true, "github.com/containerpak/steam")
+	printed := output.String()
+	if !strings.Contains(printed, "saved user override") {
+		t.Fatalf("the saved override was hidden: %q", printed)
+	}
+	if !strings.Contains(printed, "LaunchAlongsideSteam") || strings.Contains(printed, "PressureVessel.*") {
+		t.Fatalf("the prompt did not show the effective permissions: %q", printed)
 	}
 }

--- a/pkg/cpak/nested_auth.go
+++ b/pkg/cpak/nested_auth.go
@@ -224,11 +224,15 @@ func declaresDependency(parent, app types.Application) bool {
 // restrictive choice an owner can make, deny everything, as no choice at all,
 // and hand the application whatever its manifest asked for instead.
 func requestedOverride(app types.Application) types.Override {
-	userOverride, err := LoadOverride(app.Origin, app.Version)
-	if err != nil {
-		return app.ParsedOverride
+	if override, ok := storedOverride(app); ok {
+		return override
 	}
-	return userOverride
+	return app.ParsedOverride
+}
+
+func storedOverride(app types.Application) (types.Override, bool) {
+	override, err := LoadOverride(app.Origin, app.Version)
+	return override, err == nil
 }
 
 // underHostCeiling holds a policy to the widest one this host permits. The

--- a/pkg/cpak/override_test.go
+++ b/pkg/cpak/override_test.go
@@ -161,6 +161,36 @@ func TestSaveOverrideCreatesParentAndRoundTrips(t *testing.T) {
 	}
 }
 
+func TestAStoredOverrideStillReplacesARefreshedManifest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	app := types.Application{
+		Origin:  "github.com/containerpak/steam",
+		Version: "main",
+		ParsedOverride: types.Override{SessionBus: types.DBusPolicy{
+			Own: []string{"com.steampowered.PressureVessel.*"},
+		}},
+	}
+	stored := types.Override{SessionBus: types.DBusPolicy{
+		Own: []string{"com.steampowered.PressureVessel.LaunchAlongsideSteam"},
+	}}
+	if err := SaveOverride(stored, app.Origin, app.Version); err != nil {
+		t.Fatal(err)
+	}
+
+	effective := requestedOverride(app)
+	name := "com.steampowered.PressureVessel.LaunchAlongsideSteam.Instance325"
+	if !app.ParsedOverride.SessionBus.AllowsOwn(name) {
+		t.Fatal("the refreshed manifest does not allow the PID-suffixed name")
+	}
+	if effective.SessionBus.AllowsOwn(name) {
+		t.Fatal("the saved exact rule did not replace the refreshed manifest")
+	}
+	if _, ok := storedOverride(app); !ok {
+		t.Fatal("the saved override was not reported as active")
+	}
+}
+
 func TestBluetoothRequiresSharedNetwork(t *testing.T) {
 	manifest := validManifestForTest()
 	manifest.Override.SocketBluetooth = true

--- a/pkg/cpak/runner.go
+++ b/pkg/cpak/runner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/mirkobrombin/cpak/pkg/appservice"
 	"github.com/mirkobrombin/cpak/pkg/logger"
 	"github.com/mirkobrombin/cpak/pkg/systembroker"
+	"github.com/mirkobrombin/cpak/pkg/tools"
 	"github.com/mirkobrombin/cpak/pkg/types"
 )
 
@@ -172,6 +173,10 @@ func (c *Cpak) RunInstance(origin string, version string, branch string, commit 
 	if err != nil || app.CpakId == "" {
 		_ = store.Close()
 		return fmt.Errorf("no application found for origin %s and version/criteria %s: %w", origin, version, err)
+	}
+	if _, ok := storedOverride(app); ok {
+		origin := tools.SanitizeForDisplay(app.Origin)
+		logger.Printf("Using a saved user override for %s; run cpak override edit %s to inspect it", origin, origin)
 	}
 	binary, extraArgs, err = applicationServiceCommand(app, c.applicationService, binary, extraArgs)
 	if err != nil {


### PR DESCRIPTION
Related to #52.

- [x] I have read and accept the [Contributor License Agreement](https://github.com/Containerpak/cpak/blob/v2/CLA.md).